### PR TITLE
Feature/multiple configs

### DIFF
--- a/src/main/java/systems/conduit/main/core/plugin/Plugin.java
+++ b/src/main/java/systems/conduit/main/core/plugin/Plugin.java
@@ -24,8 +24,8 @@ public abstract class Plugin {
     @Getter @Setter(AccessLevel.MODULE) private PluginMeta meta;
     @Getter @Setter(AccessLevel.MODULE) private PluginState pluginState = PluginState.UNLOADED;
     @Getter(AccessLevel.PUBLIC) private final Map<Integer, Map<EventListener, List<Method>>> events = new ConcurrentHashMap<>();
-    @Setter(AccessLevel.MODULE) private Configuration config = null;
     @Getter private final Map<DatastoreBackend, Datastore> datastores = new HashMap<>();
+    @Getter private final Map<Class<? extends Configuration>, Configuration> configs = new HashMap<>();
 
     protected abstract void onEnable();
 
@@ -42,15 +42,19 @@ public abstract class Plugin {
      * @return the plugin's configuration
      */
     @SuppressWarnings("unchecked")
-    public <T extends Configuration> Optional<T> getConfig() {
+    public <T extends Configuration> Optional<T> getConfig(Class<? extends Configuration> config) {
         // TODO: Can this be improved?
 
-        if (this.config == null) return Optional.empty();
+        if (config == null) return Optional.empty();
+        if (this.configs.get(config) == null) return Optional.empty();
         try {
-            return Optional.of((T) this.config);
-        } catch (ClassCastException ignored) {
-            return Optional.empty();
-        }
+            return Optional.of((T) this.configs.get(config));
+        } catch (ClassCastException ignored) { }
+        return Optional.empty();
+    }
+
+    void setConfig(Configuration configuration) {
+        this.configs.put(configuration.getClass(), configuration);
     }
 
     public static <T extends Plugin> Optional<T> getPlugin(Class<T> type) {

--- a/src/main/java/systems/conduit/main/core/plugin/PluginClassLoader.java
+++ b/src/main/java/systems/conduit/main/core/plugin/PluginClassLoader.java
@@ -82,8 +82,9 @@ public class PluginClassLoader extends URLClassLoader {
             plugin.get().setClassLoader(this);
             plugin.get().setMeta(meta);
             // Now, we can try to get the config for this plugin.
-            Class<? extends Configuration> clazz = meta.config();
-            loadConfiguration(plugin.get(), clazz).ifPresent(plugin.get()::setConfig);
+            for (Class<? extends Configuration> clazz : meta.config()) {
+                loadConfiguration(plugin.get(), clazz).ifPresent(plugin.get()::setConfig);
+            }
             return plugin;
         }
         return Optional.empty();

--- a/src/main/java/systems/conduit/main/core/plugin/annotation/PluginMeta.java
+++ b/src/main/java/systems/conduit/main/core/plugin/annotation/PluginMeta.java
@@ -17,7 +17,7 @@ public @interface PluginMeta {
     String version();
     String author();
     Dependency[] dependencies() default {};
-    Class<? extends Configuration> config() default NoConfig.class;
+    Class<? extends Configuration>[] config() default { NoConfig.class };
     boolean reloadable() default false;
 
 }

--- a/src/main/java/systems/conduit/main/core/plugin/config/defaults/DefaultConfigurationHandler.java
+++ b/src/main/java/systems/conduit/main/core/plugin/config/defaults/DefaultConfigurationHandler.java
@@ -4,6 +4,7 @@ import com.google.gson.Gson;
 import com.google.gson.JsonIOException;
 import systems.conduit.main.Conduit;
 import systems.conduit.main.core.plugin.Plugin;
+import systems.conduit.main.core.plugin.config.Configuration;
 import systems.conduit.main.core.plugin.config.annotation.ConfigFile;
 
 import java.io.IOException;
@@ -19,28 +20,25 @@ import java.util.Map;
 public class DefaultConfigurationHandler {
 
     public static void handleDefaultForPlugin(String destination, Plugin plugin) {
-        if (!plugin.getConfig().isPresent()) {
-            // The plugin does not have a configuration, so we don't care.
-            return;
-        }
+        for (Class<? extends Configuration> configuration : plugin.getConfigs().keySet()) {
+            // Make sure this looks like a real config.
+            if (!configuration.isAnnotationPresent(ConfigFile.class)) {
+                // The plugin class does not have the ConfigFile annotation, so this is not a real config.
+                return;
+            }
 
-        // Make sure this looks like a real config.
-        if (!plugin.getConfig().get().getClass().isAnnotationPresent(ConfigFile.class)) {
-            // The plugin class does not have the ConfigFile annotation, so this is not a real config.
-            return;
+            // Since this plugin has a configuration present, next we need to get the config annotation. Then, we need to check if it has a default
+            // file listed on it. If it does, then we want to copy the file. If it does not have a default file given, then we want to create
+            // our own default entries.
+            ConfigFile configFileAnnotation = configuration.getAnnotation(ConfigFile.class);
+            if (!configFileAnnotation.defaultFile().equalsIgnoreCase("")) {
+                // A default configuration file was given, so lets copy that.
+                copyDefaultConfiguration(configFileAnnotation.defaultFile(), destination, plugin);
+                return;
+            }
+            // Looks like a default file was not given, so we're going to attempt to generate our own defaults.
+            generateDefault(destination, configuration);
         }
-
-        // Since this plugin has a configuration present, next we need to get the config annotation. Then, we need to check if it has a default
-        // file listed on it. If it does, then we want to copy the file. If it does not have a default file given, then we want to create
-        // our own default entries.
-        ConfigFile configFileAnnotation = plugin.getConfig().get().getClass().getAnnotation(ConfigFile.class);
-        if (!configFileAnnotation.defaultFile().equalsIgnoreCase("")) {
-            // A default configuration file was given, so lets copy that.
-            copyDefaultConfiguration(configFileAnnotation.defaultFile(), destination, plugin);
-            return;
-        }
-        // Looks like a default file was not given, so we're going to attempt to generate our own defaults.
-        generateDefault(destination, plugin);
     }
 
     private static void copyDefaultConfiguration(String defaultFile, String destination, Plugin plugin) {
@@ -59,10 +57,8 @@ public class DefaultConfigurationHandler {
         }
     }
 
-    private static void generateDefault(String destination, Plugin plugin) {
-        if (!plugin.getConfig().isPresent()) return;
-
-        Map<String, Object> defaultConfigOptions = DefaultParser.generateDefaults(plugin.getConfig().get());
+    private static void generateDefault(String destination, Class<? extends Configuration> configuration) {
+        Map<String, Object> defaultConfigOptions = DefaultParser.generateDefaults(configuration);
         try {
             Path destinationFile = Files.createFile(Paths.get(destination));
             String defaultString = new Gson().toJson(defaultConfigOptions);

--- a/src/main/java/systems/conduit/main/core/plugin/config/defaults/DefaultParser.java
+++ b/src/main/java/systems/conduit/main/core/plugin/config/defaults/DefaultParser.java
@@ -20,10 +20,10 @@ public class DefaultParser {
      * @param configuration the configuration file to create defaults for.
      * @return a default set of configuration options.
      */
-    static Map<String, Object> generateDefaults(Configuration configuration) {
+    static Map<String, Object> generateDefaults(Class<? extends Configuration> configuration) {
         Map<String, Object> defaults = new HashMap<>();
 
-        Field[] fields = configuration.getClass().getDeclaredFields();
+        Field[] fields = configuration.getDeclaredFields();
         for (Field field : fields) {
             // Check if this field should have a different name
             String name = field.isAnnotationPresent(SerializedName.class) ? field.getAnnotation(SerializedName.class).value() : field.getName();


### PR DESCRIPTION
Closes #57.

!!!THIS IS A BREAKING MERGE!!!

Any plugin that is currently using the `config` attribute in their `@PluginMeta` annotation will need to change the value of it to an array of configurations instead of just the single.

Additionally, any call to `Plugin#getConfig` will now be broken as well. When calling this now, provide the class of the configuration you are requesting. Ex: `MyPlugin.getConfig(FirstConfig.class)`